### PR TITLE
added route, CoasterDataIndex, and CoasterDataShow. No backend set up…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import CssBaseline from "@mui/material/CssBaseline"
 import HomePage from "./pages/HomePage"
 import NotFound from "./pages/NotFound"
 import BoardDataIndex from "./pages/BoardDataIndex"
+import CoasterDataIndex from "./pages/CoastersDataIndex"
 
 const darkTheme = createTheme({
 	palette: {
@@ -19,6 +20,7 @@ const App = () => {
 			<Routes>
 				<Route path="/" element={<HomePage />} />
 				<Route path="/boards/:boardId" element={<BoardDataIndex />} />
+				<Route path="/coasters" element={<CoasterDataIndex />} />
 				<Route path="*" element={<NotFound />} />
 			</Routes>
 		</ThemeProvider>

--- a/src/pages/CoasterDataShow.tsx
+++ b/src/pages/CoasterDataShow.tsx
@@ -1,0 +1,51 @@
+// import { useState } from "react"
+import { Box, Typography } from "@mui/material"
+import NotFound from "./NotFound"
+import Contact from "./Contact"
+
+interface Props {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	coasterData: any | undefined
+}
+
+const CoasterDataShow: React.FC<Props> = ({ coasterData }) => {
+	// const [isLoading, setIsLoading] = useState(true)
+
+	if (!coasterData) {
+		return <NotFound />
+	}
+
+	return (
+		<Box>
+			<div>
+				<Typography variant="h3">My Coaster(s)</Typography>
+				{/* <Typography variant="subtitle1">
+					{boardData.board_description}
+				</Typography>
+				<Typography variant="subtitle2">ID: {boardData.id}</Typography>
+				<Box sx={{ my: 2, textAlign: "center", height: "auto" }}>
+					{isLoading && (
+						<Box sx={{ mt: 2, textAlign: "center" }}>
+							<span>Loading Image ...</span>
+						</Box>
+					)}
+					<img
+						src={boardData.board_image_url}
+						className="cutting-board-image"
+						onLoad={() => setIsLoading(false)}
+						style={{ display: isLoading ? "none" : "block" }}
+					></img>
+				</Box>
+				<Typography variant="h5" sx={{ fontWeight: "bold" }}>
+					{boardData.customer_message}
+				</Typography>
+				<br /> */}
+			</div>
+			{/* <hr />
+			<CaringForYourBoard /> */}
+			<Contact />
+		</Box>
+	)
+}
+
+export default CoasterDataShow

--- a/src/pages/CoastersDataIndex.tsx
+++ b/src/pages/CoastersDataIndex.tsx
@@ -1,0 +1,57 @@
+import React, { useState, useMemo } from "react"
+import { useParams } from "react-router-dom"
+
+import axios from "axios"
+import { getBackendUrl } from "../utils/getBackendUrl"
+
+import CoasterDataShow from "./CoasterDataShow"
+import NotFound from "./NotFound"
+import { Box } from "@mui/material"
+
+// Need to create a type for coasterData
+
+const CoasterDataIndex: React.FC = () => {
+	const { coasterId } = useParams()
+	const [coasterData, setCoasterData] = useState({})
+	const [error, setError] = useState<boolean>(false)
+
+	useMemo(() => {
+		const fetchCoasterData = async () => {
+			try {
+				const urlPrefix = await getBackendUrl()
+				const response = await axios.get(
+					`${urlPrefix}/subapps/mycuttingboard/boards/${coasterId}`
+				)
+				if (response.status === 200) {
+					const data = await response.data
+					setCoasterData(data)
+				} else {
+					setError(true)
+				}
+			} catch (error) {
+				setError(true)
+			}
+		}
+
+		fetchCoasterData()
+	}, [coasterId])
+
+	return (
+		<Box
+			sx={{
+				margin: "0 auto",
+				display: "grid",
+				placeItems: "center",
+				textAlign: "center",
+				width: {
+					xs: 300,
+					md: 500,
+				},
+			}}
+		>
+			{error ? <NotFound /> : <CoasterDataShow coasterData={coasterData} />}{" "}
+		</Box>
+	)
+}
+
+export default CoasterDataIndex


### PR DESCRIPTION
started adding code to handle separate route for coasters.

1. Added `/coasters` route
2. Mimicked BoardDataIndex and BoardDataShow to create CoasterDataIndex and CoasterDataShow.
3. No backend logic is set up to handle this yet so we are just redirected to the home page.